### PR TITLE
Use `sysconf` library functions rather than parsing `/proc/meminfo`

### DIFF
--- a/include/Data_Functions.hpp
+++ b/include/Data_Functions.hpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <algorithm>
 #include <unistd.h>
-long int get_sys_mem();
+long long get_sys_mem();
 
 int verify_dimension(int dim);
 

--- a/include/Data_Functions.hpp
+++ b/include/Data_Functions.hpp
@@ -10,8 +10,7 @@
 #include <fstream>
 #include <iostream>
 #include <algorithm>
-#include <unistd>
-
+#include <unistd.h>
 long int get_sys_mem();
 
 int verify_dimension(int dim);

--- a/include/Data_Functions.hpp
+++ b/include/Data_Functions.hpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <iostream>
 #include <algorithm>
+#include <unistd>
 
 long int get_sys_mem();
 

--- a/src/Data_Functions.cpp
+++ b/src/Data_Functions.cpp
@@ -8,7 +8,8 @@ double epsilon = 1e-10;
 int compare_length = 1000;
 
 long long get_sys_mem() {
-    long pages = sysconf(_SC_PHYS_PAGES);
+    long pages = sysconf(_SC_AVPHYS_PAGES);
+//    long pages = sysconf(_SC_PHYS_PAGES);
     long page_size = sysconf(_SC_PAGE_SIZE);
     long mem_size = (pages * page_size);
 //    std::cout << mem_size << std::endl;

--- a/src/Data_Functions.cpp
+++ b/src/Data_Functions.cpp
@@ -23,7 +23,7 @@ int verify_dimension(int dim){
 }
 
 int possible_vector_size(float memory_size){
-    long int memory_limit = get_sys_mem();
+    long long memory_limit = get_sys_mem();
     double requested_bytes = 0;
     int dimension = 0;
     dimension = int(std::sqrt( (memory_size * 1000000) / sizeof(std::complex<double>) ));

--- a/src/Data_Functions.cpp
+++ b/src/Data_Functions.cpp
@@ -8,17 +8,11 @@ double epsilon = 1e-10;
 int compare_length = 1000;
 
 long int get_sys_mem() {
-    //Function to retrieve the amount of available memory at time of execution.
-    // variable that will hold the results.
-    char result[256] = { 0 };
-    // awk command, checked on Ubuntu 22.04
-    char const *cmd = "awk '{if (NR == 3) { print $2}}' /proc/meminfo";
-    // Open FILE which will received the streamed outputs so that they can be extracted
-    FILE *cmdfile = popen(cmd, "r");
-    fgets(result, sizeof(result), cmdfile);
-    pclose(cmdfile);
-    // stol() to return long int instead of string
-    return std::stol(result);
+    long pages = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    long mem_size = (pages * page_size);
+    std::cout << mem_size << std::endl;
+    return mem_size;
 }
 
 int verify_dimension(int dim){
@@ -29,7 +23,7 @@ int verify_dimension(int dim){
 }
 
 int possible_vector_size(float memory_size){
-    long int memory_limit = get_sys_mem()*1000;
+    long int memory_limit = get_sys_mem();
     double requested_bytes = 0;
     int dimension = 0;
     dimension = int(std::sqrt( (memory_size * 1000000) / sizeof(std::complex<double>) ));

--- a/src/Data_Functions.cpp
+++ b/src/Data_Functions.cpp
@@ -7,7 +7,7 @@ double epsilon = 1e-10;
 
 int compare_length = 1000;
 
-long int get_sys_mem() {
+long long get_sys_mem() {
     long pages = sysconf(_SC_PHYS_PAGES);
     long page_size = sysconf(_SC_PAGE_SIZE);
     long mem_size = (pages * page_size);

--- a/src/Data_Functions.cpp
+++ b/src/Data_Functions.cpp
@@ -11,7 +11,7 @@ long int get_sys_mem() {
     long pages = sysconf(_SC_PHYS_PAGES);
     long page_size = sysconf(_SC_PAGE_SIZE);
     long mem_size = (pages * page_size);
-    std::cout << mem_size << std::endl;
+//    std::cout << mem_size << std::endl;
     return mem_size;
 }
 

--- a/src/Data_Functions.cpp
+++ b/src/Data_Functions.cpp
@@ -17,8 +17,8 @@ long int get_sys_mem() {
     FILE *cmdfile = popen(cmd, "r");
     fgets(result, sizeof(result), cmdfile);
     pclose(cmdfile);
-    // stoi() to return int instead of string
-    return std::stoi(result);
+    // stol() to return long int instead of string
+    return std::stol(result);
 }
 
 int verify_dimension(int dim){


### PR DESCRIPTION
You can use `sysconf` from `<unistd.h` to get the available system memory.

As per: https://stackoverflow.com/a/2513561