### PR TITLE
Enable OpenMP for FFTW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ if ( ONEAPI )
 else()
     set(FFTW3_DIR "/usr/local" CACHE PATH "Root directory of fftw3 installation")
 
+    find_library(FFTW3_OMP_LIBRARY
+            NAMES fftw3_omp
+            PATHS ${FFTW3_DIR}/lib /usr/lib /usr/local/lib
+            NO_DEFAULT_PATH)
     find_library(FFTW3_LIBRARY
             NAMES fftw3
             PATHS ${FFTW3_DIR}/lib /usr/lib /usr/local/lib
@@ -36,6 +40,7 @@ else()
 
     include_directories(${FFTW3_INCLUDE_DIR})
     list( APPEND LIBRARIES ${FFTW3_LIBRARY} )
+    list( APPEND LIBRARIES ${FFTW3_OMP_LIBRARY} )
 endif()
 
 list( APPEND SOURCES src/FFTW_Class.cpp )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,16 +23,13 @@ else()
 
     find_library(FFTW3_OMP_LIBRARY
             NAMES fftw3_omp
-            PATHS ${FFTW3_DIR}/lib /usr/lib /usr/local/lib
-            NO_DEFAULT_PATH)
+            PATHS ${FFTW3_DIR}/lib /usr/lib /usr/local/lib)
     find_library(FFTW3_LIBRARY
             NAMES fftw3
-            PATHS ${FFTW3_DIR}/lib /usr/lib /usr/local/lib
-            NO_DEFAULT_PATH)
+            PATHS ${FFTW3_DIR}/lib /usr/lib /usr/local/lib)
     find_path(FFTW3_INCLUDE_DIR
             NAMES fftw3.h
-            PATHS ${FFTW3_DIR}/include /usr/include
-            NO_DEFAULT_PATH)
+            PATHS ${FFTW3_DIR}/include /usr/include)
 
     if(NOT FFTW3_LIBRARY AND NOT FFTW3_INCLUDE_DIR)
         message(FATAL_ERROR "fftw3 not found. Please specify FFTW3_DIR if it is in a non-standard location.")

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In order to build this benchmark, we use cmake. We recommend setting the followi
 | `CMAKE_CXX_COMPILER` |     Ex: clang++      |                                        C++ compiler to use. Tested with clang++.                                        |
 |       `ONEAPI`       |        ON/OFF        |                    Option to turn on using oneApi mkl instead of default FFTW kernel. (default OFF)                     |
 |     `ONEAPI_DIR`     | <\Path\To\oneAPImkl> | Option to pass path to fftw3, if it is not in default installation directory. (default `/opt/intel/oneapi/mkl/2025.1`)  |
-|     `FFTW3_DIR`      |   <\Path\To\FFTW3>   |          Option to pass path to fftw3, if it is not in default installation directory. If it's not in the default directory but is in `LD_LIBRARY_PATH` you can do something like `"-lfftw3_omp -lfftw3 -lm"` (default `/usr/local`)           |
+|     `FFTW3_DIR`      |   <\Path\To\FFTW3>   |          Option to pass path to fftw3, if it is not in default installation directory. (default `/usr/local`)           |
 |  `PYTHON_PLOTTING`   |        ON/OFF        |                      Option to turn on the Python library for plotting FFT results. (default OFF)                       |
 |      `CUDA_FFT`      |        ON/OFF        |                                   Option to turn on the cuFFT library. (default OFF)                                    |
 |      `CUDA_DIR`      |   <\Path\To\CUDA>    |  Option to pass path to the CUDA libraries, if it is not in default installation directory.(default `/usr/local/cuda`)  |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In order to build this benchmark, we use cmake. We recommend setting the followi
 | `CMAKE_CXX_COMPILER` |     Ex: clang++      |                                        C++ compiler to use. Tested with clang++.                                        |
 |       `ONEAPI`       |        ON/OFF        |                    Option to turn on using oneApi mkl instead of default FFTW kernel. (default OFF)                     |
 |     `ONEAPI_DIR`     | <\Path\To\oneAPImkl> | Option to pass path to fftw3, if it is not in default installation directory. (default `/opt/intel/oneapi/mkl/2025.1`)  |
-|     `FFTW3_DIR`      |   <\Path\To\FFTW3>   |          Option to pass path to fftw3, if it is not in default installation directory. (default `/usr/local`)           |
+|     `FFTW3_DIR`      |   <\Path\To\FFTW3>   |          Option to pass path to fftw3, if it is not in default installation directory. If it's not in the default directory but is in `LD_LIBRARY_PATH` you can do something like `"-lfftw3_omp -lfftw3 -lm"` (default `/usr/local`)           |
 |  `PYTHON_PLOTTING`   |        ON/OFF        |                      Option to turn on the Python library for plotting FFT results. (default OFF)                       |
 |      `CUDA_FFT`      |        ON/OFF        |                                   Option to turn on the cuFFT library. (default OFF)                                    |
 |      `CUDA_DIR`      |   <\Path\To\CUDA>    |  Option to pass path to the CUDA libraries, if it is not in default installation directory.(default `/usr/local/cuda`)  |

--- a/include/FFTW_Class.hpp
+++ b/include/FFTW_Class.hpp
@@ -12,6 +12,7 @@
 
 #include "Data_Functions.hpp"
 #include "Abstract_FFT.hpp"
+#include <omp.h>
 
 class FFTW_Class final : public Abstract_FFT{
     std::complex<double> *source_data{};

--- a/include/FFTW_Class.hpp
+++ b/include/FFTW_Class.hpp
@@ -12,7 +12,9 @@
 
 #include "Data_Functions.hpp"
 #include "Abstract_FFT.hpp"
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 class FFTW_Class final : public Abstract_FFT{
     std::complex<double> *source_data{};

--- a/src/FFTW_Class.cpp
+++ b/src/FFTW_Class.cpp
@@ -7,7 +7,8 @@ FFTW_Class::FFTW_Class(const float memory_size){
     vector_side = possible_vector_size(memory_size);
     vector_element_count = static_cast<int>(pow(vector_side, 2));
     vector_memory_size = (vector_element_count*sizeof(std::complex<double>));
-
+    fftw_init_threads();
+    fftw_plan_with_nthreads(omp_get_max_threads());
     source_data = static_cast<std::complex<double> *>(malloc(vector_memory_size));
     fill_vector(source_data, vector_element_count);
 
@@ -25,6 +26,8 @@ FFTW_Class::FFTW_Class(const int element_count){
 
     source_data = static_cast<std::complex<double> *>(malloc(vector_memory_size));
     fill_vector(source_data, vector_element_count);
+    fftw_init_threads();
+    fftw_plan_with_nthreads(omp_get_max_threads());
 
     p = fftw_plan_dft_2d(vector_side, vector_side,
                          reinterpret_cast<fftw_complex *>(source_data),
@@ -58,5 +61,6 @@ std::chrono::duration<double, std::milli> FFTW_Class::time_transform(const int r
 FFTW_Class::~FFTW_Class() {
     fftw_destroy_plan(p);
     fftw_cleanup();
+    fftw_cleanup_threads();
     free(source_data);
 }

--- a/src/FFTW_Class.cpp
+++ b/src/FFTW_Class.cpp
@@ -7,8 +7,12 @@ FFTW_Class::FFTW_Class(const float memory_size){
     vector_side = possible_vector_size(memory_size);
     vector_element_count = static_cast<int>(pow(vector_side, 2));
     vector_memory_size = (vector_element_count*sizeof(std::complex<double>));
+
+    #ifdef _OPENMP
     fftw_init_threads();
     fftw_plan_with_nthreads(omp_get_max_threads());
+    #endif
+
     source_data = static_cast<std::complex<double> *>(malloc(vector_memory_size));
     fill_vector(source_data, vector_element_count);
 
@@ -24,10 +28,13 @@ FFTW_Class::FFTW_Class(const int element_count){
     vector_element_count = element_count;
     vector_memory_size = (vector_element_count*sizeof(std::complex<double>));
 
-    source_data = static_cast<std::complex<double> *>(malloc(vector_memory_size));
-    fill_vector(source_data, vector_element_count);
+    #ifdef _OPENMP
     fftw_init_threads();
     fftw_plan_with_nthreads(omp_get_max_threads());
+    #endif
+
+    source_data = static_cast<std::complex<double> *>(malloc(vector_memory_size));
+    fill_vector(source_data, vector_element_count);
 
     p = fftw_plan_dft_2d(vector_side, vector_side,
                          reinterpret_cast<fftw_complex *>(source_data),
@@ -61,6 +68,8 @@ std::chrono::duration<double, std::milli> FFTW_Class::time_transform(const int r
 FFTW_Class::~FFTW_Class() {
     fftw_destroy_plan(p);
     fftw_cleanup();
+    #ifdef _OPENMP
     fftw_cleanup_threads();
+    #endif
     free(source_data);
 }


### PR DESCRIPTION
The current implementation runs FFTW on a single core which is very sub-optimal on CPU.

E.g. on an Nvidia GB10 with 20 cores:

Single thread (original code:

```
Repeating runs 10 times; With elements.
FFT_Code,       Mem_Size[MB],   Avg_time[ms],   Check_Value
FFTW, 501.760010, 411.31, 2.00948e+06
FFTW, 1008.190002, 1021.51, 1.82761e+07
FFTW, 2007.040039, 2259.72, 6.33331e+07
FFTW, 3969.000000, 4781.2, 6.34892e+08
FFTW, 8028.160156, 8798.77, 3.11641e+09
FFTW, 15876.000000, 20303.2, 1.75152e+10
```

versus with 20 threads on 20 cores:

```
Repeating runs 10 times; With elements.
FFT_Code,       Mem_Size[MB],   Avg_time[ms],   Check_Value
FFTW, 501.760010, 53.0416, 1.54878e+06
FFTW, 1008.190002, 1175.68, 6.5112e+06
FFTW, 2007.040039, 443.989, 4.53508e+07
FFTW, 3969.000000, 991.544, 5.36683e+08
FFTW, 8028.160156, 1387.66, 2.49537e+09
FFTW, 15876.000000, 3772.3, 1.22037e+10
```

This is quite a speed up.

I've added routines to `FFTW_Class.cpp` and an include to `FFTW_Class.hpp` as well as rules in `CMakeLists` to link in the OpenMP threaded version of FFTW instead.

I've also allowed the search for FFTW to look in "default paths" because in OSes like Ubuntu these are weird and annoying.