### PR TITLE
Fix FFTW headers in MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if ( ONEAPI )
     find_package(MKL CONFIG REQUIRED PATHS ${ONEAPI_DIR})
     find_path(FFTW_INCLUDE_DIR
            NAMES fftw3.h
-           PATHS ${ONEAPI_DIR}/include/fftw
+           PATHS ${ONEAPI_DIR}/include/fftw)
     list( APPEND LIBRARIES MKL::MKL )
     include_directories(${FFTW_INCLUDE_DIR})
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,12 @@ if ( ONEAPI )
     set(ONEAPI_DIR "/opt/intel/oneapi/mkl/2025.1" CACHE PATH "Root directory of fftw3 installation")
 
     find_package(MKL CONFIG REQUIRED PATHS ${ONEAPI_DIR})
-
+    find_path(FFTW_INCLUDE_DIR
+           NAMES fftw3.h
+           PATHS ${ONEAPI_DIR}/include/fftw
     list( APPEND LIBRARIES MKL::MKL )
+    include_directories(${FFTW_INCLUDE_DIR})
+    
 else()
     set(FFTW3_DIR "/usr/local" CACHE PATH "Root directory of fftw3 installation")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,11 @@ if ( ONEAPI )
     set(ONEAPI_DIR "/opt/intel/oneapi/mkl/2025.1" CACHE PATH "Root directory of fftw3 installation")
 
     find_package(MKL CONFIG REQUIRED PATHS ${ONEAPI_DIR})
-    find_path(FFTW_INCLUDE_DIR
+    find_path(FFTW3_INCLUDE_DIR
            NAMES fftw3.h
-           PATHS ${ONEAPI_DIR}/include/fftw)
+           PATHS ${MKL_INCLUDE}/fftw)
     list( APPEND LIBRARIES MKL::MKL )
-    include_directories(${FFTW_INCLUDE_DIR})
+    include_directories(${FFTW3_INCLUDE_DIR})
     
 else()
     set(FFTW3_DIR "/usr/local" CACHE PATH "Root directory of fftw3 installation")


### PR DESCRIPTION
If we include fftw headers in our code, we need to add `${MKL_INCLUDE}/fftw` to the include paths.

This PR does this which means we can run multithreaded on Intel MKL correctly too!

```
[almalinux@uccaoke-base-01-ba5807a216 build]$ cat output.txt 
Repeating runs 10 times; With elements.
FFT_Code,       Mem_Size[MB],   Avg_time[ms],   Check_Value
FFTW, 501.760010, 46.8697, 200588
FFTW, 1008.190002, 110.657, 1.59017e+07
FFTW, 2007.040039, 199.097, 1.19158e+07
FFTW, 3969.000000, 524.09, 3.37211e+08
FFTW, 8028.160156, 998.819, 2.21144e+09
FFTW, 15876.000000, 2388.71, 1.06641e+10
Run_Finished
```

(16 cores of Intel Icelake)