### PR TITLE
Change rocFFT source_data allocation behavior to match cuFFT

### DIFF
--- a/src/rocFFT_Class.cpp
+++ b/src/rocFFT_Class.cpp
@@ -1,6 +1,8 @@
 //
 // Created by marcuskeil on 31/01/25.
 //
+// Modified on 11/02/26 by Owain Kenway to change malloc behavior to match Cuda -> massive speedup!
+// Specifically -> do allocation of source data on the device.
 #include "../include/rocFFT_Class.hpp"
 
 rocFFT_Class::rocFFT_Class(const float memory_size){
@@ -21,7 +23,7 @@ rocFFT_Class::rocFFT_Class(const int element_count){
 
 void rocFFT_Class::level_check() {
     vector_memory_size = (vector_element_count*sizeof(std::complex<double>));
-    source_data = static_cast<std::complex<double> *>(malloc(vector_memory_size));
+    assert( hipMalloc(&source_data, vector_memory_size) == hipSuccess);
     fill_vector(source_data, vector_element_count);
 
     assert( hipSetDevice(0) == hipSuccess );
@@ -143,7 +145,7 @@ std::chrono::duration<double, std::milli> rocFFT_Class::time_transform(const int
 }
 
 rocFFT_Class::~rocFFT_Class() {
-    free(source_data);
+    assert( hipFree(source_data) == hipSuccess );
     assert( hipFree(gpu_source_data) == hipSuccess );
     gpu_source_data = nullptr;
 


### PR DESCRIPTION
The original rocFFT code allocates the source_data vector on the host meaning that it has to be copied to the device every time it is used to fill a bufffer on the device.

This can be contrasted with the cuFFT version which uses Cuda's managed memory which allows Cuda to choose. This means it uses the device memory by default (unless that is full) which means the copy is device -> device.

Making this change drastically improves the rocFFT version to be comparible to the Cuda version.

Before:

```
[uccaoke@atlas build]$ ./FFT_Bench -a -c 10
[uccaoke@atlas build]$ cat output.txt 
Repeating runs 10 times; With elements.
FFT_Code,       Mem_Size[MB],   Avg_time[ms],   Check_Value
rocFFT, 501.760010, 36.4349, 2.05898e+06
rocFFT, 1008.190002, 59.1218, 1.62413e+07
rocFFT, 2007.040039, 111.846, 7.86461e+07
rocFFT, 3969.000000, 221.573, 4.54094e+08
rocFFT, 8028.160156, 445.093, 2.15939e+09
rocFFT, 15876.000000, 900.39, 1.27524e+10
Run_Finished
```

After:

```
[uccaoke@atlas build]$ ./FFT_Bench -a -c 10
[uccaoke@atlas build]$ cat output.txt 
Repeating runs 10 times; With elements.
FFT_Code,       Mem_Size[MB],   Avg_time[ms],   Check_Value
rocFFT, 501.760010, 2.76493, 341772
rocFFT, 1008.190002, 7.00081, 5.74701e+06
rocFFT, 2007.040039, 11.4802, 1.26226e+07
rocFFT, 3969.000000, 24.3928, 1.20879e+08
rocFFT, 8028.160156, 53.6175, 1.84729e+08
rocFFT, 15876.000000, 104.588, 2.32683e+09
Run_Finished
```