### PR TITLE
Tell CUDA to prefer device memory for source array

### DIFF
--- a/src/cuFFT_Class.cpp
+++ b/src/cuFFT_Class.cpp
@@ -29,6 +29,17 @@ cuFFT_Class::cuFFT_Class(const float memory_size){ // memory_size given in MB
                 vector_element_count*sizeof(std::complex<double>),
                 cudaMemAttachGlobal
         );
+
+    int device;
+    cudaGetDevice(&device);
+
+    cudaMemAdvise(
+                source_data,
+                vector_element_count*sizeof(std::complex<double>),
+                cudaMemAdviseSetPreferredLocation,
+                device
+        );
+
     fill_vector(source_data, vector_element_count);
 
     level_check();
@@ -44,6 +55,17 @@ cuFFT_Class::cuFFT_Class(const int element_count){ // memory_size given in MB
                 vector_element_count*sizeof(std::complex<double>),
                 cudaMemAttachGlobal
         );
+
+    int device;
+    cudaGetDevice(&device);
+
+    cudaMemAdvise(
+                source_data,
+                vector_element_count*sizeof(std::complex<double>),
+                cudaMemAdviseSetPreferredLocation,
+                device
+        );
+
     fill_vector(source_data, vector_element_count);
 
     level_check();


### PR DESCRIPTION
Apparently `cudaMallocManaged` seems to prefer host memory which as we saw with the AMD platforms is a bad place to store the source array. Hinting to it to prefer device memory gives a speed-up of approximately 1.5x on our GH200 - probably more on discrete cards but I no longer have any to test with.