### PR TITLE
This PR updates the device handling for Cuda 12+ (causes failures in Cuda 13)

### DIFF
--- a/src/cuFFT_Class.cpp
+++ b/src/cuFFT_Class.cpp
@@ -33,7 +33,7 @@ cuFFT_Class::cuFFT_Class(const float memory_size){ // memory_size given in MB
     int device;
     cudaGetDevice(&device);
     
-    cudaMemLocation device_dev = { cudaMemLocationType::kDevice, static_cast<unsigned int>(device) };
+    cudaMemLocation device_dev = { cudaMemLocationTypeDevice, static_cast<unsigned int>(device) };
     cudaMemAdvise(
                 source_data,
                 vector_element_count*sizeof(std::complex<double>),
@@ -60,7 +60,7 @@ cuFFT_Class::cuFFT_Class(const int element_count){ // memory_size given in MB
     int device;
     cudaGetDevice(&device);
 
-    cudaMemLocation device_dev = { cudaMemLocationType::kDevice, static_cast<unsigned int>(device) };
+    cudaMemLocation device_dev = { cudaMemLocationTypeDevice, static_cast<unsigned int>(device) };
     cudaMemAdvise(
                 source_data,
                 vector_element_count*sizeof(std::complex<double>),

--- a/src/cuFFT_Class.cpp
+++ b/src/cuFFT_Class.cpp
@@ -32,12 +32,13 @@ cuFFT_Class::cuFFT_Class(const float memory_size){ // memory_size given in MB
 
     int device;
     cudaGetDevice(&device);
-
+    
+    cudaMemLocation device_dev = { cudaMemLocationType::kDevice, static_cast<unsigned int>(device) };
     cudaMemAdvise(
                 source_data,
                 vector_element_count*sizeof(std::complex<double>),
                 cudaMemAdviseSetPreferredLocation,
-                device
+                device_dev
         );
 
     fill_vector(source_data, vector_element_count);
@@ -59,11 +60,12 @@ cuFFT_Class::cuFFT_Class(const int element_count){ // memory_size given in MB
     int device;
     cudaGetDevice(&device);
 
+    cudaMemLocation device_dev = { cudaMemLocationType::kDevice, static_cast<unsigned int>(device) };
     cudaMemAdvise(
                 source_data,
                 vector_element_count*sizeof(std::complex<double>),
                 cudaMemAdviseSetPreferredLocation,
-                device
+                device_dev
         );
 
     fill_vector(source_data, vector_element_count);

--- a/src/cuFFT_Class.cpp
+++ b/src/cuFFT_Class.cpp
@@ -33,7 +33,7 @@ cuFFT_Class::cuFFT_Class(const float memory_size){ // memory_size given in MB
     int device;
     cudaGetDevice(&device);
     
-    cudaMemLocation device_dev = { cudaMemLocationTypeDevice, static_cast<unsigned int>(device) };
+    cudaMemLocation device_dev = { cudaMemLocationTypeDevice, device };
     cudaMemAdvise(
                 source_data,
                 vector_element_count*sizeof(std::complex<double>),
@@ -60,7 +60,7 @@ cuFFT_Class::cuFFT_Class(const int element_count){ // memory_size given in MB
     int device;
     cudaGetDevice(&device);
 
-    cudaMemLocation device_dev = { cudaMemLocationTypeDevice, static_cast<unsigned int>(device) };
+    cudaMemLocation device_dev = { cudaMemLocationTypeDevice, device };
     cudaMemAdvise(
                 source_data,
                 vector_element_count*sizeof(std::complex<double>),


### PR DESCRIPTION
The way `cudaMemAdvise` works has changed in Cuda 12+ and needs the device to be mem location rather than a device id. The old way still worked in 12.x but fails in 13.x.